### PR TITLE
Fixed update Posts controller and schema

### DIFF
--- a/src/repositories/hashtagsRepository.js
+++ b/src/repositories/hashtagsRepository.js
@@ -51,6 +51,13 @@ export async function insertHashtagsPosts(postId, hashtagId) {
     return rowCount;
 }
 
+export async function verifyPostHashtags(postId, hashtagId) {
+    return await connection.query(
+        'SELECT * FROM "hashtagPosts" WHERE "postId"=$1 AND "hashtagId"=$2',
+        [postId, hashtagId]
+    );
+}
+
 export async function deleteHashtagLink(postId) {
     return await connection.query(
         'DELETE FROM "hashtagPosts" WHERE "postId"=$1',
@@ -116,5 +123,6 @@ export const hashtagsRepository = {
     selectAllHashtags,
     selectPostsByHashtag,
     getHashtagByPostId,
-    deleteHashtagLink
+    deleteHashtagLink,
+    verifyPostHashtags
 }

--- a/src/repositories/postRepository.js
+++ b/src/repositories/postRepository.js
@@ -13,13 +13,6 @@ export async function insertPost(urlData, comment, userId) {
     );
 }
 
-export async function verifyPostHashtags(postId, hashtagId) {
-    return await connection.query(
-        'SELECT * FROM hashtagPosts WHERE "postId"=$1, "hastagId"=$2',
-        [postId, hashtagId]
-    );
-}
-
 export async function getOnePostById(id) {
     return await connection.query(
         'SELECT * FROM posts WHERE id=$1',
@@ -64,10 +57,10 @@ export async function getAllPosts() {
     }
 }
 
-export async function updatePost(url, comment, id) {
+export async function updatePost(comment, id) {
     return await connection.query(
-        'UPDATE posts SET url=$1,comment=$2 WHERE id=$3',
-        [url, comment, id]
+        'UPDATE posts SET comment=$1 WHERE id=$2',
+        [comment, id]
     )
 }
 

--- a/src/routers/postRouters.js
+++ b/src/routers/postRouters.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 import validateSchemas from "../middlewares/validateSchemas.js";
 import { createHashtags } from "../middlewares/hashtagsMiddlewares.js";
 import postSchema from "../schemas/postSchema.js";
+import postUpdateSchema from "../schemas/postUpdateSchema.js";
 import {
     createPost,
     listAllPosts,
@@ -12,9 +13,9 @@ import tokenVerify from "../middlewares/tokenVerify.js";
 
 const router = Router();
 
-router.post("/posts", tokenVerify, validateSchemas(postSchema), createHashtags ,createPost);
+router.post("/posts", tokenVerify, validateSchemas(postSchema), createHashtags, createPost);
 router.get("/posts", tokenVerify, listAllPosts);
-router.put("/posts/:id", tokenVerify, validateSchemas(postSchema), editPost);
+router.put("/posts/:id", tokenVerify, validateSchemas(postUpdateSchema), createHashtags, editPost);
 router.delete("/posts/:id", tokenVerify, deletePost);
 
 export default router;

--- a/src/schemas/postSchema.js
+++ b/src/schemas/postSchema.js
@@ -2,7 +2,7 @@ import joi from 'joi';
 
 const postSchema = joi.object({
     url:joi.string().uri().required(),
-    comment:joi.any().optional()
+    comment:joi.string().min(0)
 });
 
 export default postSchema

--- a/src/schemas/postUpdateSchema.js
+++ b/src/schemas/postUpdateSchema.js
@@ -1,0 +1,7 @@
+import joi from 'joi';
+
+const postUpdateSchema = joi.object({
+    comment:joi.string().min(0)
+});
+
+export default postUpdateSchema


### PR DESCRIPTION
Lógica nova no controlador updatePosts: 
Antes era verificado se o link post-hashtag já existe e, se não, era inserido o novo link em hashtagPosts. Como se trata de edição de post, isso dá margem pra manter links do post com hashtags apagadas, pq não eram verificadas. 
Agora, achei mais fácil deletar todos os links de hastags daquele post e inserir novamente com base na array de hashtagIds retornada pelo middleware. Isso tbm envolve menos requisições à DB 