### PR TITLE
Fix query posts

### DIFF
--- a/src/controllers/postControllers.js
+++ b/src/controllers/postControllers.js
@@ -11,7 +11,6 @@ import {
 import { commentsRepository } from "../repositories/commentsRepository.js";
 
 import {
-  formatedPosts,
   hashtagsRepository,
 } from "../repositories/hashtagsRepository.js";
 import { deleteLiked, deleteLikeLink, likesPost } from "../repositories/likesRepository.js";

--- a/src/repositories/hashtagsRepository.js
+++ b/src/repositories/hashtagsRepository.js
@@ -105,7 +105,9 @@ export async function formatedPosts(posts) {
     if (posts) {
         for (const post of posts) {
             const { rows: likes } = await getLikeByPostId(post.postId);
+            const { rows: shared } = await getRepostsByPostId(post.postId);
             post.likes = likes
+            post.shared = shared
         }
         const newPost = posts.map(p=>({
                 postId:p.postId,
@@ -121,9 +123,9 @@ export async function formatedPosts(posts) {
                     image:p.urlImage,
                     url:p.urlLink
                 },
-                likesCount:p.likesCount,
+                likesCount:p.likes.length,
                 likes:p.likes,
-                repostCount:p.repostCount,
+                repostCount:p.shared.length,
                 repostedBy:{
                     id:p.repostedBy,
                     name:p.repostedByName

--- a/src/repositories/hashtagsRepository.js
+++ b/src/repositories/hashtagsRepository.js
@@ -78,9 +78,7 @@ export async function selectPostsByHashtag(hashtag) {
         p."urlDescription",
         p."urlImage",
         p."urlLink",
-        p.id as "postId",
-        COUNT(l.id) as "likesCount",
-        COUNT(s.id) as "repostCount"
+        p.id as "postId"
         FROM posts p 
         LEFT JOIN users u ON u.id = p."userId"
         LEFT JOIN "hashtagPosts" hp ON hp."postId" = p.id

--- a/src/repositories/postRepository.js
+++ b/src/repositories/postRepository.js
@@ -29,8 +29,6 @@ export async function getAllPosts(userId) {
         p."urlImage",
         p."urlLink",
         p.id as "postId",
-        COUNT(l.id) as "likesCount",
-        COUNT(s.id) as "repostCount",
         NULL as "repostedByName",
         NULL as "repostedBy",
         p."createdAt"
@@ -54,8 +52,6 @@ export async function getAllPosts(userId) {
         p."urlImage",
         p."urlLink",
         p.id as "postId",
-        COUNT(l.id) as "likesCount",
-        COUNT(s.id) as "repostCount",
         u2.name as "repostedByName",
         u2.id as "repostedBy",
         s."createdAt"

--- a/src/repositories/usersRepository.js
+++ b/src/repositories/usersRepository.js
@@ -29,9 +29,7 @@ export async function getPostsByUserId(userId) {
             p."urlDescription",
             p."urlImage",
             p."urlLink",
-            p.id as "postId",
-            COUNT(l.id) as "likesCount",
-            COUNT(s.id) as "repostCount"
+            p.id as "postId"
             FROM posts p
             LEFT JOIN users u ON u.id=p."userId"
             LEFT JOIN likes l ON l."postId"=p.id


### PR DESCRIPTION
Fixed bug in likes and re-posts count that considered all posts from posts list (including re-posts). Now it is performed after the query and accounts only for original posts